### PR TITLE
Fix card image width

### DIFF
--- a/estilos.css
+++ b/estilos.css
@@ -68,6 +68,7 @@ nav ul.menu {
 
 .card img {
     width: 100%;
+    max-width: 250px;
     height: auto;
     max-height: 150px;
     object-fit: contain;


### PR DESCRIPTION
## Summary
- limit card images to 250px so they don't exceed the card

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685ce412c8c483329d09d3b20aa0d622