### PR TITLE
Add responsive layout for mobile

### DIFF
--- a/estilos.css
+++ b/estilos.css
@@ -4,10 +4,12 @@ body {
     padding: 0;
 }
 
-/* Contenedor principal con ancho fijo */
+/* Contenedor principal */
 .contenedor {
-    width: 1080px;
+    max-width: 1080px;
+    width: 90%;
     margin: 0 auto;
+    box-sizing: border-box;
 }
 
 header {
@@ -24,6 +26,7 @@ nav ul.menu {
     display: flex;
     justify-content: center;
     gap: 25px;
+    flex-wrap: wrap;
 }
 
 /* Estilo para cada enlace del menú */
@@ -48,7 +51,7 @@ nav ul.menu {
 /* Contenedor de tarjetas */
 .cards {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
     gap: 20px;
     padding: 20px 0;
 }
@@ -92,4 +95,19 @@ nav ul.menu {
 
 .action-btn:active {
     transform: scale(0.95);
+}
+
+@media (max-width: 600px) {
+    header {
+        padding: 15px;
+    }
+    nav ul.menu {
+        gap: 15px;
+    }
+    .cards {
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    }
+    .action-btn {
+        width: 100%;
+    }
 }

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="es">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Página de Inicio</title>
     <link rel="stylesheet" href="estilos.css">
 </head>

--- a/login.html
+++ b/login.html
@@ -2,6 +2,7 @@
 <html lang="es">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Login</title>
     <link rel="stylesheet" href="estilos.css">
 </head>

--- a/tutoriales.html
+++ b/tutoriales.html
@@ -2,6 +2,7 @@
 <html lang="es">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Tutoriales</title>
     <link rel="stylesheet" href="estilos.css">
 </head>


### PR DESCRIPTION
## Summary
- enable viewport scaling in all pages
- make `.contenedor` responsive
- allow nav menu wrapping
- adjust card grid layout and add mobile breakpoint

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685cee100c88833285c6182dd0e5039e